### PR TITLE
Broad installation hotfix

### DIFF
--- a/scripts/svtk
+++ b/scripts/svtk
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2017 Matthew Stone <mstone5@mgh.harvard.edu>
+# Copyright 2017 Matthew Stone <mstone5@mgh.harvard.edu>
 # Distributed under terms of the MIT license.
 
 """


### PR DESCRIPTION
The preferred encoding on the Broad system doesn't default to UTF-8, which broke the parsing in setuptools' develop function (linked below). I removed the copyright symbol from the svtk script to circumvent this until an encoding solution is found.

https://github.com/pypa/setuptools/issues/1230
https://github.com/pypa/setuptools/blob/master/setuptools/command/develop.py#L186