### PR TITLE
fix ValueError in t-test

### DIFF
--- a/svtk/baf/BAFpysam.py
+++ b/svtk/baf/BAFpysam.py
@@ -125,7 +125,7 @@ class DeletionTest:
                 # stat1=(stat-np.mean(self.nullratio))/(np.std(self.nullratio))
                 # gmm = mixture.BayesianGaussianMixture(n_components=3, covariance_type='spherical').fit(a.reshape(-1,1))
                 # ans=stats.norm.cdf(stat1)
-                ans=self.gmm.score(stat)
+                ans=self.gmm.score(np.array(stat).reshape(1,-1))
                 return 10**-stat,ans
         else:
             # tstat,pvalue=stats.ttest_ind(testlist,self.nullratio)


### PR DESCRIPTION
I'm getting lots of value errors in the baf-test when running module02.
No idea whether I've guessed the correct incantation, but this 1-line fix does make the exception go away.
Don't merge without assessing the correctness of the change!